### PR TITLE
Making M2 main landing page.

### DIFF
--- a/docs/source/how-tos/receivers/mustang2.rst
+++ b/docs/source/how-tos/receivers/mustang2.rst
@@ -4,7 +4,7 @@
 MUSTANG-2 How-To Guides
 #####################################################
 
-Practical step-by-step guides to help you using MUSTANG-2. 
+Practical step-by-step guides to help you use MUSTANG-2. 
 
 ----------------
 

--- a/docs/source/how-tos/receivers/mustang2/mustang2_proposal.rst
+++ b/docs/source/how-tos/receivers/mustang2/mustang2_proposal.rst
@@ -14,10 +14,15 @@ Proposal Requirements
 
 Team Approval
 -------------
+All MUSTANG-2 proposals are shared-risk and must be approved by the :ref:`MUSTANG-2 instrument team <MUSTANG-2 Instrument Team>`. Furthermore, the entire MUSTANG-2 instrument team **must** be included as **co-investigators on the proposal**. 
 
-All MUSTANG-2 proposals are shared-risk and must be approved by the :ref:`MUSTANG-2 instrument team <MUSTANG-2 Instrument Team>`. Furthermore, the entire MUSTANG-2 instrument team **must** be included as co-investigators on the proposal. 
+In order to get your proposal approved by the MUSTANG-2 team, contact one or all of the instrument team member listed under :ref:`the Contact section <MUSTANG-2 Contact Details>` of the MUSTANG-2 Instrument Team webpage and send a draft of your proposal **at least one week in advance** of the proposal deadline. The MUSTANG-2 team will principally focus on the technical feasibility of a proposal and make suggestions accordingly. 
 
-In order to get your proposal approved by the MUSTANG-2 team, contact one or all of the members listed under the Contact section on :ref:`MUSTANG-2 instrument team <MUSTANG-2 Instrument Team>` webpage with a draft of your proposal at least a week in advance of the proposal deadline. The MUSTANG-2 team will principally focus on the technical feasibility of a proposal and make suggestions accordingly. The technical justification on a proposal should reference publicly available mapping speeds (e.g. from the MUSTANG-2 mapping :ref:`webpage <MUSTANG-2 Mapping Information>` and/or :download:`MUSTANG-2 mapping speeds memo </_static/mustang2_documents/MUSTANG_2_Mapping_Speeds_public.pdf>`). The GBT sensitivity calculator does not currently incorporate MUSTANG-2 mapping speeds.
+Technical Justification
+-----------------------
+The technical justification on a proposal should reference publicly available mapping speeds (e.g. from the MUSTANG-2 mapping :ref:`webpage <MUSTANG-2 Mapping Information>` and/or :download:`MUSTANG-2 mapping speeds memo </_static/mustang2_documents/MUSTANG_2_Mapping_Speeds_public.pdf>`). The GBT sensitivity calculator does not currently incorporate MUSTANG-2 mapping speeds.
+
+If you are targeting a specific S/N for your proposal and you have an extended object, you must account for/explore the effect of filtering and include this in your technical justification. You can run simulations using `M2_ProposalTools <https://m2-tj.readthedocs.io/en/latest/index.html>`_, run your own simulations, or consult the instrument team.
 
 Overhead observing constraints
 -------------------------------
@@ -25,14 +30,17 @@ The overhead for MUSTANG-2 is dominated by initial setup and calibration. We gen
 
 Source visibility considerations
 --------------------------------
-Daytime observing at 90 GHz is currently not advised. The changing solar illumination gives rise to thermal distortions in the telescope structure which make calibrating 90 GHz data extremely difficult. Useful 3mm observations are currently only possible between 3h after sunset and a half hour past sunrise. Further cooler temperatures are required for observing at 90 GHz thus the high-frequency observing season for MUSTANG-2 is typically ~October - late April/early May. Thus your target must be visibile to the GBT 3h after sunset and a half hour past sunrise in ~October - late April/early May. 
+Daytime observing at 90 GHz is currently not advised. The changing solar illumination gives rise to thermal distortions in the telescope structure which make calibrating 90 GHz data extremely difficult. Useful 3mm observations are currently only possible between 3h after sunset and a half hour past sunrise. Further cooler temperatures are required for observing at 90 GHz thus the high-frequency observing season for MUSTANG-2 is typically ~October - May. Thus your target must be visibile to the GBT 3h after sunset and a half hour past sunrise in ~October - May. 
 
 Other things of note
 ====================
+Proposal Tools
+--------------
+`M2_ProposalTools <https://m2-tj.readthedocs.io/en/latest/index.html>`_ is a Python library for simulating MUSTANG-2 observations. A specific application of this library is that a proposer can simulate the effect of filtering on the S/N acquired.
 
 Data and Observing
 ------------------
-Though the entire MUSTANG-2 instrument team will be invovled in the proposal process, conversely, the MUSTANG-2 team will reduce the data and provide appropriate data products (principally a calibrated map, transfer function, and beam characterization) to the proposal team (see :ref:`the list of possible data products<MUSTANG-2 Deliverables>`. End-to-end data reduction is currently fairly involved. We will work to provide documentation on data processing and hope to eventually allow proposers to process their own data. 
+Though the entire MUSTANG-2 instrument team will be involved in the proposal process, conversely, the MUSTANG-2 team will reduce the data and provide appropriate data products (principally a calibrated map, transfer function, and beam characterization) to the proposal team (see :ref:`the list of possible data products<MUSTANG-2 Deliverables>`. End-to-end data reduction is currently fairly involved. We will work to provide documentation on data processing and hope to eventually allow proposers to process their own data. 
 
 MUSTANG-2 instrument team also asks that the PI and team get trained to observe with MUSTANG-2 and observe for their project whenever possible.
 
@@ -46,7 +54,3 @@ As a general rule one can use the relationship between integration time (t) and 
 	* From the radiometer equation :math:`t \propto` 1/:math:`\sigma ^2`
 	* set up in a proportional relationship :math:`t_2`/:math:`t_1` :math:`\propto` (:math:`\sigma_1`/:math:`\sigma_2`) :math:`^2` where :math:`t_2` is the required integration time that you are solving for, :math:`t_1` is 1 hour, :math:`\sigma_1` is the sensitivity corresponding to the map size from the table on the mapping :ref:`webpage <MUSTANG-2 Mapping Information>`, and :math:`\sigma_2` is the desired sensitivity that you have calculated
 	* :math:`t_2` :math:`\propto` (:math:`\sigma_1`/:math:`\sigma_2`) :math:`^2` :math:`\times` :math:`t_1` and thus :math:`t_2` is your integration time
-
-Proposal Tools
---------------
-`M2_ProposalTools <https://m2-tj.readthedocs.io/en/latest/index.html>`_ is a Python library for simulating MUSTANG-2 observations. A specific application of this library is that a proposer can simulate the effect of filtering on the S/N acquired.

--- a/docs/source/references/receivers/mustang2.rst
+++ b/docs/source/references/receivers/mustang2.rst
@@ -4,7 +4,7 @@
 MUSTANG-2
 #########
 
-Below are various technical aspects and references that an observer or a MUSTANG-2 team member may want to know about MUSTANG-2.
+Welcome to the hub of MUSTANG-2 documentation! On this page you will find links to instrument information, proposal instructions, how-to guides, various technical aspects, and references.
 
 ----------------
 
@@ -47,8 +47,13 @@ Below are various technical aspects and references that an observer or a MUSTANG
     mustang2/mustang2_overview
     mustang2/mustang2_instrument_team
 
+Proposal Information
+--------------------
+Go :ref:`here <mustang2_proposal>` for requirements and information on submitting a proposal to use MUSTANG-2.
 
-
+How-to Guides
+-------------
+Go :ref:`here <mustang2-howtos>` for guides on how set-up and observe with MUSTANG-2 and information on MUSTANG-2 data products/reduction.
 
 Technical Aspects
 -----------------

--- a/docs/source/references/receivers/mustang2/mustang2_instrument_team.rst
+++ b/docs/source/references/receivers/mustang2/mustang2_instrument_team.rst
@@ -19,6 +19,6 @@ The following are members of the MUSTANG-2 Instrument Team and should be include
 - Joshiwa van Marrewijk
 
 
-Contact Details
----------------
-Please contact Simon Dicker at simon.dicker -at- gmail.com, Brian Mason at bmason -at- nrao -dot- edu, or Emily Moravec at emoravec -at- nrao -dot- edu for permission concerning proposal submission or any other inquiries concerning MUSTANG-2.
+MUSTANG-2 Contact Details
+-------------------------
+Please contact Simon Dicker at simon.dicker -at- gmail.com, Brian Mason at bmason -at- nrao -dot- edu, or Emily Moravec at emoravec -at- nrao -dot- edu for permission/approval concerning proposal submission or any other inquiries concerning MUSTANG-2.


### PR DESCRIPTION
Made a gbtdocs equivalent to the M2 GBO landing page for the upcoming proposal call. On this highlighted the proposal information page. Made a few other minor changes to get ready for the proposal call: added soft requirement to include information about filtering in technical justification and reordered the proposal information page.